### PR TITLE
Change to vtkOpenGLGlyphMapper

### DIFF
--- a/Rendering/vtkOpenGLGlyph3DMapper.cxx
+++ b/Rendering/vtkOpenGLGlyph3DMapper.cxx
@@ -74,9 +74,8 @@ vtkOpenGLGlyph3DMapper::vtkOpenGLGlyph3DMapper()
   this->LastWindow = 0;
 
   this->ScalarsToColorsPainter = vtkScalarsToColorsPainter::New();
-  this->ScalarsToColorsPainter->SetInformation(this->PainterInformation);
-
   this->PainterInformation = vtkInformation::New();
+  this->ScalarsToColorsPainter->SetInformation(this->PainterInformation);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Makes two changes:
- Passes its information object to the ScalarsToColorsPainter. Without this, any changes to the information object will not be reflected in the painter, leading to incorrect rendering.
- Removes extraneous output to cout.
