### PR TITLE
Fixed buiding SimpleView example under VTK 6 (using VTK_LIBRARIES)

### DIFF
--- a/Examples/GUI/Qt/SimpleView/CMakeLists.txt
+++ b/Examples/GUI/Qt/SimpleView/CMakeLists.txt
@@ -64,14 +64,8 @@ ENDIF (${CMAKE_BUILD_TOOL} MATCHES "devenv")
 ADD_EXECUTABLE( SimpleView MACOSX_BUNDLE ${SimpleViewSrcs} ${UISrcs} ${MOCSrcs} ${ResourceSrcs})
 
 TARGET_LINK_LIBRARIES( SimpleView
-  QVTK
   ${QT_LIBRARIES}
-  vtkRendering
-  vtkGraphics
-  vtkIO
-  vtkCommon
-  vtkInfovis
-  vtkViews
+  ${VTK_LIBRARIES}
 )
 
 


### PR DESCRIPTION
The GUI/Qt/SimpleView example did not work, since the CMakeLists was not migrated to VTK6, yet.
