### PR TITLE
Fix compilation by gcc-4.9

### DIFF
--- a/Filters/ParallelMPI/vtkDistributedDataFilter.cxx
+++ b/Filters/ParallelMPI/vtkDistributedDataFilter.cxx
@@ -1091,7 +1091,10 @@ vtkDataSet *vtkDistributedDataFilter::TestFixTooFewInputFiles(vtkDataSet *input)
   vtkIdType cellsPerNode = numTotalCells / nprocs;
 
   vtkIdList **sendCells = new vtkIdList * [ nprocs ];
-  memset(sendCells, 0, sizeof(vtkIdList *) * nprocs);
+  
+  if (sizeof(vtkIdList *) * nprocs > 0) {
+    memset(sendCells, 0, sizeof(vtkIdList *) * nprocs);
+  }
 
   if (numConsumers == nprocs - 1)
     {
@@ -1582,7 +1585,9 @@ vtkFloatArray **
   // Exchange int arrays
 
   float **recvArrays = new float * [nprocs];
-  memset(recvArrays, 0, sizeof(float *) * nprocs);
+  if (sizeof(float *) * nprocs > 0) {
+    memset(recvArrays, 0, sizeof(float *) * nprocs);
+  }
 
   if (sendSize[me] > 0)  // sent myself an array
     {
@@ -1703,7 +1708,9 @@ vtkIdTypeArray **
   // Exchange int arrays
 
   vtkIdType **recvArrays = new vtkIdType * [nprocs];
-  memset(recvArrays, 0, sizeof(vtkIdType *) * nprocs);
+  if (sizeof(vtkIdType *) * nprocs > 0) {
+    memset(recvArrays, 0, sizeof(vtkIdType *) * nprocs);
+  }
 
   if (sendSize[me] > 0)  // sent myself an array
     {
@@ -2807,7 +2814,9 @@ void vtkDistributedDataFilter::AddConstantUnsignedCharPointArray(
 
   unsigned char *vals = new unsigned char [npoints];
 
-  memset(vals, val, npoints);
+  if (npoints > 0) {
+    memset(vals, val, npoints);
+  }
 
   vtkUnsignedCharArray *Array = vtkUnsignedCharArray::New();
   Array->SetName(arrayName);
@@ -2827,7 +2836,9 @@ void vtkDistributedDataFilter::AddConstantUnsignedCharCellArray(
 
   unsigned char *vals = new unsigned char [ncells];
 
-  memset(vals, val, ncells);
+  if (ncells > 0) {
+    memset(vals, val, ncells);
+  }
 
   vtkUnsignedCharArray *Array = vtkUnsignedCharArray::New();
   Array->SetName(arrayName);
@@ -3026,7 +3037,9 @@ int vtkDistributedDataFilter::AssignGlobalNodeIds(vtkUnstructuredGrid *grid)
   vtkIdType nGridPoints = grid->GetNumberOfPoints();
 
   vtkIdType *numPointsOutside = new vtkIdType [nprocs];
-  memset(numPointsOutside, 0, sizeof(vtkIdType) * nprocs);
+  if (sizeof(vtkIdType) * nprocs > 0) {
+    memset(numPointsOutside, 0, sizeof(vtkIdType) * nprocs);
+  }
 
   vtkIdTypeArray *globalIds = vtkIdTypeArray::New();
   globalIds->SetNumberOfValues(nGridPoints);
@@ -3108,10 +3121,16 @@ int vtkDistributedDataFilter::AssignGlobalNodeIds(vtkUnstructuredGrid *grid)
   // global ID back?
 
   vtkFloatArray **ptarrayOut = new vtkFloatArray * [nprocs];
-  memset(ptarrayOut, 0, sizeof(vtkFloatArray *) * nprocs);
+  
+  if (sizeof(vtkFloatArray *) * nprocs > 0) {
+    memset(ptarrayOut, 0, sizeof(vtkFloatArray *) * nprocs);
+  }
 
   vtkIdTypeArray **localIds     = new vtkIdTypeArray * [nprocs];
-  memset(localIds, 0, sizeof(vtkIdTypeArray *) * nprocs);
+  
+  if (sizeof(vtkIdTypeArray *) * nprocs > 0) {
+    memset(localIds, 0, sizeof(vtkIdTypeArray *) * nprocs);
+  }
 
   vtkIdType *next = new vtkIdType [nprocs];
   vtkIdType *next3 = new vtkIdType [nprocs];
@@ -3286,7 +3305,9 @@ vtkIdTypeArray **vtkDistributedDataFilter::FindGlobalPointIds(
     {
     // There are no cells in my assigned region
 
-    memset(gids, 0, sizeof(vtkIdTypeArray *) * nprocs);
+    if (sizeof(vtkIdTypeArray *) * nprocs > 0) {
+      memset(gids, 0, sizeof(vtkIdTypeArray *) * nprocs);
+    }
 
     return gids;
     }
@@ -3491,7 +3512,10 @@ vtkIdTypeArray **vtkDistributedDataFilter::MakeProcessLists(
   std::multimap<int, int>::iterator mapIt;
 
   vtkIdTypeArray **processList = new vtkIdTypeArray * [nprocs];
-  memset(processList, 0, sizeof (vtkIdTypeArray *) * nprocs);
+
+  if (sizeof (vtkIdTypeArray *) * nprocs > 0) {
+    memset(processList, 0, sizeof (vtkIdTypeArray *) * nprocs);
+  }
 
   for (int i=0; i<nprocs; i++)
     {
@@ -3581,7 +3605,9 @@ vtkIdTypeArray **vtkDistributedDataFilter::GetGhostPointIds(
   vtkIdType numPoints = grid->GetNumberOfPoints();
 
   vtkIdTypeArray **ghostPtIds = new vtkIdTypeArray * [nprocs];
-  memset(ghostPtIds, 0, sizeof(vtkIdTypeArray *) * nprocs);
+  if (sizeof(vtkIdTypeArray *) * nprocs) {
+    memset(ghostPtIds, 0, sizeof(vtkIdTypeArray *) * nprocs);
+  }
 
   if (numPoints < 1)
     {


### PR DESCRIPTION
VTK fails to build during compilation by gcc-4.9 with the
following message:

CMakeFiles/vtkFiltersParallelMPI.dir/vtkDistributedDataFilter.cxx.o: In
function `memset':
/usr/include/x86_64-linux-gnu/bits/string3.h:81: warning: memset used
with constant zero length parameter; this could be due to transposed
parameters
collect2: error: ld returned 1 exit status

This patch sets if-condition before all "memsets" in
vtkDistributedDataFilter and checkes, whether the number
of bytes to be set by memset is more than 0 to escape this
error.
