### PR TITLE
Web/JavaScript/CMakeLists.txt needs include(vtkPythonPackages)

### DIFF
--- a/Web/Applications/CMakeLists.txt
+++ b/Web/Applications/CMakeLists.txt
@@ -12,6 +12,7 @@ set(WEB_APPLICATIONS
 
 set(WEB_APPS_DEPENDS)
 
+include(vtkPythonPackages) # for copy_files_recursive
 foreach(_app ${WEB_APPLICATIONS})
   file(MAKE_DIRECTORY "${VTK_WWW_DIR}/apps/${_app}")
 


### PR DESCRIPTION
Having changed the build options to
VTK_USE_SYSTEM_AUTOBAHN=YES
VTK_USE_SYSTEM_TWISTED=YES
VTK_USE_SYSTEM_ZOPE=YES
I discovered that Web/JavaScript/CMakeLists.txt is missing an include(vtkPythonPackages) for the copy_files_recursive definition.