### PR TITLE
fix: reinterpret_cast from 'nullptr_t' is not allowed

### DIFF
--- a/Rendering/Core/vtkLabeledContourMapper.cxx
+++ b/Rendering/Core/vtkLabeledContourMapper.cxx
@@ -632,7 +632,7 @@ bool vtkLabeledContourMapper::PrepareRender(vtkRenderer *ren, vtkActor *act)
 
     // The value will be replaced in the next loop:
     labelMap.insert(std::pair<double, vtkTextProperty*>(
-                      metric.Value, reinterpret_cast<vtkTextProperty*>(NULL)));
+                      metric.Value, reinterpret_cast<vtkTextProperty*>(0)));
     }
 
   // Now that all present scalar values are known, assign text properties:


### PR DESCRIPTION
clang 3.5+ (specailly on BSD) doesn't allow reinterpret_cast over NULL