### PR TITLE
Update vtkPolyDataConnectivityFilter.cxx

### DIFF
--- a/Filters/Core/vtkPolyDataConnectivityFilter.cxx
+++ b/Filters/Core/vtkPolyDataConnectivityFilter.cxx
@@ -353,7 +353,7 @@ int vtkPolyDataConnectivityFilter::RequestData(
           // If we asked to mark the visited point ids, mark them.
           if (this->MarkVisitedPointIds)
           {
-            this->VisitedPointIds->InsertUniqueId(id);
+            this->VisitedPointIds->InsertUniqueId(pts[i]);
           }
         }
         newCellId = output->InsertNextCell(this->Mesh->GetCellType(cellId),
@@ -389,7 +389,7 @@ int vtkPolyDataConnectivityFilter::RequestData(
             // If we asked to mark the visited point ids, mark them.
             if (this->MarkVisitedPointIds)
             {
-              this->VisitedPointIds->InsertUniqueId(id);
+              this->VisitedPointIds->InsertUniqueId(pts[i]);
             }
 
           }
@@ -416,7 +416,7 @@ int vtkPolyDataConnectivityFilter::RequestData(
           // If we asked to mark the visited point ids, mark them.
           if (this->MarkVisitedPointIds)
           {
-            this->VisitedPointIds->InsertUniqueId(id);
+            this->VisitedPointIds->InsertUniqueId(pts[i]);
           }
         }
         newCellId = output->InsertNextCell(this->Mesh->GetCellType(cellId),


### PR DESCRIPTION
If I understand correctly. The function of SetMarkVisitedPointIds() is, that you can reteive a list of point id's that correlates to the selected, hence visited cell data of the filter input. In the current version of the filter, one only gets the visited order of the points and not their original id's. This is because the "this->PointMap[pts[i]]" entry is filled using the "PointNumber" variable, rather than the actual point id. So one basically gets the order of the point in the filter output, rather than the expected selected point id's of the input.