### PR TITLE
Link against the rendering backend

### DIFF
--- a/Examples/Infovis/Cxx/CMakeLists.txt
+++ b/Examples/Infovis/Cxx/CMakeLists.txt
@@ -13,6 +13,7 @@ set(VTK_Modules
   vtkInfovisLayout
   vtkInteractionStyle
   vtkRenderingLabel
+  vtkRendering${VTK_RENDERING_BACKEND}
   vtkViewsInfovis
 )
 if(TARGET vtkGUISupportQt AND


### PR DESCRIPTION
Linking against the rendering backend is not done for the examples in the Infovis directory. At runtime, this leads to a seg-fault:

    Generic Warning: In /home/manuel/work/99_temp/VTK-8.1.0/Rendering/Core/vtkRenderer.cxx, line 55
    Error: no override found for 'vtkRenderer'.
    
    Generic Warning: In /home/manuel/work/99_temp/VTK-8.1.0/Rendering/Core/vtkRenderWindow.cxx, line 43
    Error: no override found for 'vtkRenderWindow'.
    
    
    Program received signal SIGSEGV, Segmentation fault.
    0x00007ffff749821b in vtkRenderViewBase::vtkRenderViewBase (this=0x5555557a0180)
        at /home/manuel/work/99_temp/VTK-8.1.0/Views/Core/vtkRenderViewBase.cxx:33
    33        this->RenderWindow->AddRenderer(this->Renderer);

Thanks for your interest in contributing to VTK!  The GitHub repository
is a mirror provided for convenience, but VTK does not use GitHub pull
requests for contribution.  Please see

  https://gitlab.kitware.com/vtk/vtk/tree/master/CONTRIBUTING.md

for contribution instructions.  GitHub OAuth may be used to sign in.
