### PR TITLE
Fixed control points clamp function to handle NaN value

### DIFF
--- a/Charts/Core/vtkControlPointsItem.cxx
+++ b/Charts/Core/vtkControlPointsItem.cxx
@@ -31,6 +31,7 @@
 #include "vtkSmartPointer.h"
 #include "vtkTransform2D.h"
 #include "vtkVectorOperators.h"
+#include "vtkMath.h"
 
 #include <algorithm>
 #include <cassert>
@@ -439,7 +440,7 @@ bool vtkControlPointsItem::ClampPos(double pos[2], double bounds[4])
     return false;
   }
   bool clamped = false;
-  if (pos[0] < bounds[0])
+  if (pos[0] < bounds[0] || vtkMath::IsNan(pos[0]))
   {
     pos[0] = bounds[0];
     clamped = true;
@@ -449,7 +450,7 @@ bool vtkControlPointsItem::ClampPos(double pos[2], double bounds[4])
     pos[0] = bounds[1];
     clamped = true;
   }
-  if (pos[1] < 0.)
+  if (pos[1] < 0. || vtkMath::IsNan(pos[0]))
   {
     pos[1] = 0.;
     clamped = true;


### PR DESCRIPTION
If the user clicks in a plot that has an invalid (0,0) range, then in vtkContextScene::ProcessItem that is called after mouse events, the mapped mouse position becomes NaN, due to invalid matrix in the ContextScene's transform. This NaN position is then added to the function as a control point with an invalid NaN value. This fix makes sure this does not happen, by clamping the NaN values to minimum bounds on x axis, and 0 on y axis (any value comparison returns false if an operand is NaN, so need to check explicitly).

Thanks for your interest in contributing to VTK!  The GitHub repository
is a mirror provided for convenience, but VTK does not use GitHub pull
requests for contribution.  Please see

  https://gitlab.kitware.com/vtk/vtk/tree/master/CONTRIBUTING.md

for contribution instructions.  GitHub OAuth may be used to sign in.
