### PR TITLE
Removing FT_CALLBACK_DEF

### DIFF
--- a/Rendering/FreeType/vtkFreeTypeTools.cxx
+++ b/Rendering/FreeType/vtkFreeTypeTools.cxx
@@ -377,9 +377,8 @@ FTC_CMapCache* vtkFreeTypeTools::GetCMapCache()
   return this->CMapCache;
 }
 
-//------------------------------------------------------------------------------
-FT_CALLBACK_DEF(FT_Error)
-vtkFreeTypeToolsFaceRequester(
+//----------------------------------------------------------------------------
+FT_Error vtkFreeTypeToolsFaceRequester(
   FTC_FaceID face_id, FT_Library lib, FT_Pointer request_data, FT_Face* face)
 {
 #if VTK_FTFC_DEBUG_CD

--- a/Rendering/FreeTypeFontConfig/vtkFontConfigFreeTypeTools.cxx
+++ b/Rendering/FreeTypeFontConfig/vtkFontConfigFreeTypeTools.cxx
@@ -29,8 +29,7 @@ vtkStandardNewMacro(vtkFontConfigFreeTypeTools);
 namespace
 {
 // The FreeType face requester callback:
-FT_CALLBACK_DEF(FT_Error)
-vtkFontConfigFreeTypeToolsFaceRequester(
+FT_Error vtkFontConfigFreeTypeToolsFaceRequester(
   FTC_FaceID face_id, FT_Library lib, FT_Pointer request_data, FT_Face* face)
 {
   // Get a pointer to the current vtkFontConfigFreeTypeTools object


### PR DESCRIPTION
- This is to provide compatibility with freetype-2.10.4 where
FT_CALLBACK_DEF is kept as internal for the freetype library. freetype
2.10.4 seems to be affected by a security vulnerabilty (update to 2.10.4
is recommended) (ttps://security.gentoo.org/glsa/202010-07)

- This removal does not have any effect for freetype < 2.10.4.

For reference `FT_CALLBACK_DEF` is defined in `compiler-macros.h`:
```
#ifdef __cplusplus
#define FT_CALLBACK_DEF( x )  extern "C"  x
#else
#define FT_CALLBACK_DEF( x )  static  x
#endif
```

Thanks for your interest in contributing to VTK!  The GitHub repository
is a mirror provided for convenience, but VTK does not use GitHub pull
requests for contribution.  Please see

  https://gitlab.kitware.com/vtk/vtk/-/tree/master/CONTRIBUTING.md

for contribution instructions.  GitHub OAuth may be used to sign in.
