### PR TITLE
vtkRenderingExternalCxxTests: use imported GLUT target in cmake

### DIFF
--- a/Rendering/External/Testing/Cxx/CMakeLists.txt
+++ b/Rendering/External/Testing/Cxx/CMakeLists.txt
@@ -2,7 +2,6 @@ if(NOT APPLE)
   # GLUT tests don't work on Apple.
   # see discussion on vtk/vtk!5169
 
-  # TODO: Make FindGLUT use imported targets.
   find_package(GLUT REQUIRED)
   include_directories(${GLUT_INCLUDE_DIR})
 
@@ -12,5 +11,5 @@ if(NOT APPLE)
 
   vtk_test_cxx_executable(vtkRenderingExternalCxxTests tests)
   target_link_libraries(vtkRenderingExternalCxxTests PRIVATE
-    ${GLUT_LIBRARY})
+    GLUT::GLUT)
 endif()


### PR DESCRIPTION
This tests failed to compile on some newer version of cmake. As specified in cmake 3.12 document, GLUT_LIBRARY is not the correct variable for GLUT library.