### PR TITLE
missing initialization of member DataSet when initialize picking oper…

### DIFF
--- a/Rendering/Core/vtkAreaPicker.cxx
+++ b/Rendering/Core/vtkAreaPicker.cxx
@@ -74,6 +74,7 @@ void vtkAreaPicker::Initialize()
   this->vtkAbstractPropPicker::Initialize();
   this->Prop3Ds->RemoveAllItems();
   this->Mapper = nullptr;
+  this->DataSet = nullptr;
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
The miss initialization of member variable **DataSet** in function **vtkAreaPicker::Initialize** will cause crash of **PCL program** randomly when **empty area picking** of **QVTKOpenGLNativeWidget** which holding a pcl::visualization::PCLVisualizer as actual visualizer.

The crash will happen if:
step1: picking a subset of cloud points holding by PCLVisualizer.
step2: remove this subet set from the PCLVisualizer.
step3: picking the region without any cloud points
the dangling member variable **DataSet** will romdonly cause the if condition at line 174 of **pcl::visualization::PointPickingCallback::performAreaPick** become true. Then the dangling points->GetPointData() will cause crash.


Thanks for your interest in contributing to VTK!  The GitHub repository
is a mirror provided for convenience, but VTK does not use GitHub pull
requests for contribution.  Please see

  https://gitlab.kitware.com/vtk/vtk/-/tree/master/CONTRIBUTING.md

for contribution instructions.  GitHub OAuth may be used to sign in.
