### PR TITLE
Fix EnSight Reader for double quotes issue and scripts variable

### DIFF
--- a/IO/EnSight/vtkEnSightGoldBinaryReader.cxx
+++ b/IO/EnSight/vtkEnSightGoldBinaryReader.cxx
@@ -39,6 +39,7 @@
 #include <string>
 #include <sys/stat.h>
 #include <vector>
+#include <algorithm>
 
 #if defined(_WIN32)
 #define VTK_STAT_STRUCT struct _stat64
@@ -55,7 +56,6 @@
 #define VTK_STAT_FUNC stat64
 #endif
 
-VTK_ABI_NAMESPACE_BEGIN
 class vtkEnSightGoldBinaryReader::vtkUtilities
 {
   static int GetDestinationComponent(int srcComponent, int numComponents)
@@ -346,6 +346,14 @@ int vtkEnSightGoldBinaryReader::InitializeFile(const char* fileName)
     return 0;
   }
   std::string sfilename;
+  std::string filename_string(fileName);
+  char quotes = '\"';
+  size_t found = filename_string.find(quotes);
+  if (found != std::string::npos)
+  {
+    filename_string.erase(
+      std::remove(filename_string.begin(), filename_string.end(), quotes), filename_string.end());
+  }
   if (this->FilePath)
   {
     sfilename = this->FilePath;
@@ -353,12 +361,12 @@ int vtkEnSightGoldBinaryReader::InitializeFile(const char* fileName)
     {
       sfilename += "/";
     }
-    sfilename += fileName;
+    sfilename += filename_string;
     vtkDebugMacro("full path to geometry file: " << sfilename);
   }
   else
   {
-    sfilename = fileName;
+    sfilename = filename_string;
   }
 
   if (this->OpenFile(sfilename.c_str()) == 0)
@@ -1244,6 +1252,14 @@ int vtkEnSightGoldBinaryReader::ReadMeasuredGeometryFile(
     return 0;
   }
   std::string sfilename;
+  std::string filename_string(fileName);
+  char quotes = '\"';
+  size_t found = filename_string.find(quotes);
+  if (found != std::string::npos)
+  {
+    filename_string.erase(
+      std::remove(filename_string.begin(), filename_string.end(), quotes), filename_string.end());
+  }
   if (this->FilePath)
   {
     sfilename = this->FilePath;
@@ -1251,12 +1267,12 @@ int vtkEnSightGoldBinaryReader::ReadMeasuredGeometryFile(
     {
       sfilename += "/";
     }
-    sfilename += fileName;
+    sfilename += filename_string;
     vtkDebugMacro("full path to measured geometry file: " << sfilename);
   }
   else
   {
-    sfilename = fileName;
+    sfilename = filename_string;
   }
 
   if (this->OpenFile(sfilename.c_str()) == 0)
@@ -1396,6 +1412,14 @@ bool vtkEnSightGoldBinaryReader::OpenVariableFile(const char* fileName, const ch
   }
 
   std::string sfilename;
+  std::string filename_string(fileName);
+  char quotes = '\"';
+  size_t found = filename_string.find(quotes);
+  if (found != std::string::npos)
+  {
+    filename_string.erase(
+      std::remove(filename_string.begin(), filename_string.end(), quotes), filename_string.end());
+  }
   if (this->FilePath)
   {
     sfilename = this->FilePath;
@@ -1403,12 +1427,12 @@ bool vtkEnSightGoldBinaryReader::OpenVariableFile(const char* fileName, const ch
     {
       sfilename += "/";
     }
-    sfilename += fileName;
+    sfilename += filename_string;
     vtkDebugMacro("full path to variable (" << type << ") file: " << sfilename);
   }
   else
   {
-    sfilename = fileName;
+    sfilename = filename_string;
   }
 
   if (this->OpenFile(sfilename.c_str()) == 0)
@@ -3625,4 +3649,3 @@ void vtkEnSightGoldBinaryReader::AddFileIndexToCache(const char* fileName)
   }
   this->GoldIFile->seekg(0l, ios::beg);
 }
-VTK_ABI_NAMESPACE_END

--- a/IO/EnSight/vtkEnSightGoldReader.cxx
+++ b/IO/EnSight/vtkEnSightGoldReader.cxx
@@ -36,8 +36,8 @@
 #include <sstream>
 #include <string>
 #include <vector>
+#include <algorithm>
 
-VTK_ABI_NAMESPACE_BEGIN
 vtkStandardNewMacro(vtkEnSightGoldReader);
 
 class vtkEnSightGoldReader::FileOffsetMapInternal
@@ -179,6 +179,14 @@ int vtkEnSightGoldReader::ReadGeometryFile(
     return 0;
   }
   std::string sfilename;
+  std::string filename_string(fileName);
+  char quotes = '\"';
+  size_t found = filename_string.find(quotes);
+  if (found != std::string::npos)
+  {
+    filename_string.erase(
+      std::remove(filename_string.begin(), filename_string.end(), quotes), filename_string.end());
+  }
   if (this->FilePath)
   {
     sfilename = this->FilePath;
@@ -186,12 +194,12 @@ int vtkEnSightGoldReader::ReadGeometryFile(
     {
       sfilename += "/";
     }
-    sfilename += fileName;
+    sfilename += filename_string;
     vtkDebugMacro("full path to geometry file: " << sfilename);
   }
   else
   {
-    sfilename = fileName;
+    sfilename = filename_string;
   }
 
   this->IS = new vtksys::ifstream(sfilename.c_str(), ios::in);
@@ -378,6 +386,14 @@ int vtkEnSightGoldReader::ReadMeasuredGeometryFile(
     return 0;
   }
   std::string sfilename;
+  std::string filename_string(fileName);
+  char quotes = '\"';
+  size_t found = filename_string.find(quotes);
+  if (found != std::string::npos)
+  {
+    filename_string.erase(
+      std::remove(filename_string.begin(), filename_string.end(), quotes), filename_string.end());
+  }
   if (this->FilePath)
   {
     sfilename = this->FilePath;
@@ -385,12 +401,12 @@ int vtkEnSightGoldReader::ReadMeasuredGeometryFile(
     {
       sfilename += "/";
     }
-    sfilename += fileName;
+    sfilename += filename_string;
     vtkDebugMacro("full path to measured geometry file: " << sfilename);
   }
   else
   {
-    sfilename = fileName;
+    sfilename = filename_string;
   }
 
   this->IS = new vtksys::ifstream(sfilename.c_str(), ios::in);
@@ -510,6 +526,14 @@ bool vtkEnSightGoldReader::OpenVariableFile(const char* fileName, const char* va
   }
 
   std::string sfilename;
+  std::string filename_string(fileName);
+  char quotes = '\"';
+  size_t found = filename_string.find(quotes);
+  if (found != std::string::npos)
+  {
+    filename_string.erase(
+      std::remove(filename_string.begin(), filename_string.end(), quotes), filename_string.end());
+  }
   if (this->FilePath)
   {
     sfilename = this->FilePath;
@@ -517,12 +541,12 @@ bool vtkEnSightGoldReader::OpenVariableFile(const char* fileName, const char* va
     {
       sfilename += "/";
     }
-    sfilename += fileName;
+    sfilename += filename_string;
     vtkDebugMacro("full path to variable (" << variableType << ") file: " << sfilename);
   }
   else
   {
-    sfilename = fileName;
+    sfilename = filename_string;
   }
 
   this->IS = new vtksys::ifstream(sfilename.c_str(), ios::in);
@@ -2695,4 +2719,3 @@ void vtkEnSightGoldReader::PrintSelf(ostream& os, vtkIndent indent)
 {
   this->Superclass::PrintSelf(os, indent);
 }
-VTK_ABI_NAMESPACE_END

--- a/IO/EnSight/vtkEnSightReader.cxx
+++ b/IO/EnSight/vtkEnSightReader.cxx
@@ -36,7 +36,6 @@
 
 //------------------------------------------------------------------------------
 typedef std::vector<vtkSmartPointer<vtkIdList>> vtkEnSightReaderCellIdsTypeBase;
-VTK_ABI_NAMESPACE_BEGIN
 class vtkEnSightReaderCellIdsType : public vtkEnSightReaderCellIdsTypeBase
 {
 };
@@ -441,6 +440,29 @@ int vtkEnSightReader::RequestInformation(vtkInformation* vtkNotUsed(request),
   return this->CaseFileRead;
 }
 
+
+//-----------------------------------------------------------------------------
+int vtkEnSightReader::ReadCaseFileSripts(char* line)
+{
+  /* The scripts variable is a new area of the EnSight Gold Format which is used
+  to reference an eventual metadata xml file for handling units. The function
+  just skips it.*/
+  int lineRead;
+
+  lineRead = this->ReadNextDataLine(line);
+  while (lineRead)
+  {
+    if (strncmp(line, "metadata:", 9) == 0)
+    {
+      vtkDebugMacro("Skipping metadata");
+    }
+    lineRead = this->ReadNextDataLine(line);
+  }
+  return lineRead;
+}
+
+
+
 //------------------------------------------------------------------------------
 int vtkEnSightReader::ReadCaseFileGeometry(char* line)
 {
@@ -456,20 +478,20 @@ int vtkEnSightReader::ReadCaseFileGeometry(char* line)
   {
     if (strncmp(line, "model:", 6) == 0)
     {
-      if (sscanf(line, " %*s %d%*[ \t]%d%*[ \t]%s", &timeSet, &fileSet, subLine) == 3)
+      if (sscanf(line, " %*s %d%*[ \t]%d%*[ \t]%[^\t\n]", &timeSet, &fileSet, subLine) == 3)
       {
         this->GeometryTimeSet = timeSet;
         this->GeometryFileSet = fileSet;
         this->SetGeometryFileName(subLine);
         vtkDebugMacro(<< this->GetGeometryFileName());
       }
-      else if (sscanf(line, " %*s %d%*[ \t]%s", &timeSet, subLine) == 2)
+      else if (sscanf(line, " %*s %d%*[ \t]%[^\t\n]", &timeSet, subLine) == 2)
       {
         this->GeometryTimeSet = timeSet;
         this->SetGeometryFileName(subLine);
         vtkDebugMacro(<< this->GetGeometryFileName());
       }
-      else if (sscanf(line, " %*s %s", subLine) == 1)
+      else if (sscanf(line, " %*s %[^\t\n]", subLine) == 1)
       {
         this->SetGeometryFileName(subLine);
         vtkDebugMacro(<< this->GetGeometryFileName());
@@ -477,20 +499,20 @@ int vtkEnSightReader::ReadCaseFileGeometry(char* line)
     }
     else if (strncmp(line, "measured:", 9) == 0)
     {
-      if (sscanf(line, " %*s %d%*[ \t]%d%*[ \t]%s", &timeSet, &fileSet, subLine) == 3)
+      if (sscanf(line, " %*s %d%*[ \t]%d%*[ \t]%[^\t\n]", &timeSet, &fileSet, subLine) == 3)
       {
         this->MeasuredTimeSet = timeSet;
         this->MeasuredFileSet = fileSet;
         this->SetMeasuredFileName(subLine);
         vtkDebugMacro(<< this->GetMeasuredFileName());
       }
-      else if (sscanf(line, " %*s %d%*[ \t]%s", &timeSet, subLine) == 2)
+      else if (sscanf(line, " %*s %d%*[ \t]%[^\t\n]", &timeSet, subLine) == 2)
       {
         this->MeasuredTimeSet = timeSet;
         this->SetMeasuredFileName(subLine);
         vtkDebugMacro(<< this->GetMeasuredFileName());
       }
-      else if (sscanf(line, " %*s %s", subLine) == 1)
+      else if (sscanf(line, " %*s %[^\t\n]", subLine) == 1)
       {
         this->SetMeasuredFileName(subLine);
         vtkDebugMacro(<< this->GetMeasuredFileName());
@@ -498,7 +520,7 @@ int vtkEnSightReader::ReadCaseFileGeometry(char* line)
     }
     else if (strncmp(line, "match:", 6) == 0)
     {
-      sscanf(line, " %*s %s", subLine);
+      sscanf(line, " %*s %[^\t\n]", subLine);
       this->SetMatchFileName(subLine);
       vtkDebugMacro(<< this->GetMatchFileName());
     }
@@ -533,7 +555,7 @@ int vtkEnSightReader::ReadCaseFileVariable(char* line)
   lineRead = this->ReadNextDataLine(line);
   while (lineRead && strncmp(line, "FORMAT", 6) != 0 && strncmp(line, "GEOMETRY", 8) != 0 &&
     strncmp(line, "VARIABLE", 8) != 0 && strncmp(line, "TIME", 4) != 0 &&
-    strncmp(line, "FILE", 4) != 0)
+    strncmp(line, "FILE", 4) != 0 && strncmp(line, "SCRIPTS", 7) != 0)
   {
     if (strncmp(line, "constant", 8) == 0)
     {
@@ -551,19 +573,19 @@ int vtkEnSightReader::ReadCaseFileVariable(char* line)
           this->VariableTimeSetIds->InsertNextId(timeSet);
           this->VariableFileSetIds->InsertNextId(fileSet);
           this->AddVariableDescription(subLine);
-          sscanf(line, " %*s %*s %*s %*d %*d %*s %s", subLine);
+          sscanf(line, " %*s %*s %*s %*d %*d %*s %[^\t\n]", subLine);
         }
         else if (sscanf(line, " %*s %*s %*s %d %s", &timeSet, subLine) == 2)
         {
           this->VariableTimeSetIds->InsertNextId(timeSet);
           this->AddVariableDescription(subLine);
-          sscanf(line, " %*s %*s %*s %*d %*s %s", subLine);
+          sscanf(line, " %*s %*s %*s %*d %*s %[^\t\n]", subLine);
         }
         else if (sscanf(line, " %*s %*s %*s %s", subLine) == 1)
         {
           this->VariableTimeSetIds->InsertNextId(1);
           this->AddVariableDescription(subLine);
-          sscanf(line, " %*s %*s %*s %*s %s", subLine);
+          sscanf(line, " %*s %*s %*s %*s %[^\t\n]", subLine);
         }
         this->AddVariableType();
         this->NumberOfScalarsPerNode++;
@@ -577,19 +599,19 @@ int vtkEnSightReader::ReadCaseFileVariable(char* line)
           this->VariableTimeSetIds->InsertNextId(timeSet);
           this->VariableFileSetIds->InsertNextId(fileSet);
           this->AddVariableDescription(subLine);
-          sscanf(line, " %*s %*s %*s %*d %*d %*s %s", subLine);
+          sscanf(line, " %*s %*s %*s %*d %*d %*s %[^\t\n]", subLine);
         }
         else if (sscanf(line, " %*s %*s %*s %d %s", &timeSet, subLine) == 2)
         {
           this->VariableTimeSetIds->InsertNextId(timeSet);
           this->AddVariableDescription(subLine);
-          sscanf(line, " %*s %*s %*s %*d %*s %s", subLine);
+          sscanf(line, " %*s %*s %*s %*d %*s %[^\t\n]", subLine);
         }
         else if (sscanf(line, " %*s %*s %*s %s", subLine) == 1)
         {
           this->VariableTimeSetIds->InsertNextId(1);
           this->AddVariableDescription(subLine);
-          sscanf(line, " %*s %*s %*s %*s %s", subLine);
+          sscanf(line, " %*s %*s %*s %*s %[^\t\n]", subLine);
         }
         this->AddVariableType();
         this->NumberOfScalarsPerElement++;
@@ -603,19 +625,19 @@ int vtkEnSightReader::ReadCaseFileVariable(char* line)
           this->VariableTimeSetIds->InsertNextId(timeSet);
           this->VariableFileSetIds->InsertNextId(fileSet);
           this->AddVariableDescription(subLine);
-          sscanf(line, " %*s %*s %*s %*s %*d %*d %*s %s", subLine);
+          sscanf(line, " %*s %*s %*s %*s %*d %*d %*s %[^\t\n]", subLine);
         }
         else if (sscanf(line, " %*s %*s %*s %*s %d %s", &timeSet, subLine) == 2)
         {
           this->VariableTimeSetIds->InsertNextId(timeSet);
           this->AddVariableDescription(subLine);
-          sscanf(line, " %*s %*s %*s %*s %*d %*s %s", subLine);
+          sscanf(line, " %*s %*s %*s %*s %*d %*s %[^\t\n]", subLine);
         }
         else if (sscanf(line, " %*s %*s %*s %*s %s", subLine) == 1)
         {
           this->VariableTimeSetIds->InsertNextId(1);
           this->AddVariableDescription(subLine);
-          sscanf(line, " %*s %*s %*s %*s %*s %s", subLine);
+          sscanf(line, " %*s %*s %*s %*s %*s %[^\t\n]", subLine);
         }
         this->AddVariableType();
         this->NumberOfScalarsPerMeasuredNode++;
@@ -635,19 +657,19 @@ int vtkEnSightReader::ReadCaseFileVariable(char* line)
           this->VariableTimeSetIds->InsertNextId(timeSet);
           this->VariableFileSetIds->InsertNextId(fileSet);
           this->AddVariableDescription(subLine);
-          sscanf(line, " %*s %*s %*s %*d %*d %*s %s", subLine);
+          sscanf(line, " %*s %*s %*s %*d %*d %*s %[^\t\n]", subLine);
         }
         else if (sscanf(line, " %*s %*s %*s %d %s", &timeSet, subLine) == 2)
         {
           this->VariableTimeSetIds->InsertNextId(timeSet);
           this->AddVariableDescription(subLine);
-          sscanf(line, " %*s %*s %*s %*d %*s %s", subLine);
+          sscanf(line, " %*s %*s %*s %*d %*s %[^\t\n]", subLine);
         }
         else if (sscanf(line, " %*s %*s %*s %s", subLine) == 1)
         {
           this->VariableTimeSetIds->InsertNextId(1);
           this->AddVariableDescription(subLine);
-          sscanf(line, " %*s %*s %*s %*s %s", subLine);
+          sscanf(line, " %*s %*s %*s %*s %[^\t\n]", subLine);
         }
         this->AddVariableType();
         this->NumberOfVectorsPerNode++;
@@ -661,19 +683,19 @@ int vtkEnSightReader::ReadCaseFileVariable(char* line)
           this->VariableTimeSetIds->InsertNextId(timeSet);
           this->VariableFileSetIds->InsertNextId(fileSet);
           this->AddVariableDescription(subLine);
-          sscanf(line, " %*s %*s %*s %*d %*d %*s %s", subLine);
+          sscanf(line, " %*s %*s %*s %*d %*d %*s %[^\t\n]", subLine);
         }
         else if (sscanf(line, " %*s %*s %*s %d %s", &timeSet, subLine) == 2)
         {
           this->VariableTimeSetIds->InsertNextId(timeSet);
           this->AddVariableDescription(subLine);
-          sscanf(line, " %*s %*s %*s %*d %*s %s", subLine);
+          sscanf(line, " %*s %*s %*s %*d %*s %[^\t\n]", subLine);
         }
         else if (sscanf(line, " %*s %*s %*s %s", subLine) == 1)
         {
           this->VariableTimeSetIds->InsertNextId(1);
           this->AddVariableDescription(subLine);
-          sscanf(line, " %*s %*s %*s %*s %s", subLine);
+          sscanf(line, " %*s %*s %*s %*s %[^\t\n]", subLine);
         }
         this->AddVariableType();
         this->NumberOfVectorsPerElement++;
@@ -687,19 +709,19 @@ int vtkEnSightReader::ReadCaseFileVariable(char* line)
           this->VariableTimeSetIds->InsertNextId(timeSet);
           this->VariableFileSetIds->InsertNextId(fileSet);
           this->AddVariableDescription(subLine);
-          sscanf(line, " %*s %*s %*s %*s %*d %*d %*s %s", subLine);
+          sscanf(line, " %*s %*s %*s %*s %*d %*d %*s %[^\t\n]", subLine);
         }
         else if (sscanf(line, " %*s %*s %*s %*s %d %s", &timeSet, subLine) == 2)
         {
           this->VariableTimeSetIds->InsertNextId(timeSet);
           this->AddVariableDescription(subLine);
-          sscanf(line, " %*s %*s %*s %*s %*d %*s %s", subLine);
+          sscanf(line, " %*s %*s %*s %*s %*d %*s %[^\t\n]", subLine);
         }
         else if (sscanf(line, " %*s %*s %*s %*s %s", subLine) == 1)
         {
           this->VariableTimeSetIds->InsertNextId(1);
           this->AddVariableDescription(subLine);
-          sscanf(line, " %*s %*s %*s %*s %*s %s", subLine);
+          sscanf(line, " %*s %*s %*s %*s %*s %[^\t\n]", subLine);
         }
         this->AddVariableType();
         this->NumberOfVectorsPerMeasuredNode++;
@@ -752,19 +774,19 @@ int vtkEnSightReader::ReadCaseFileVariable(char* line)
           this->VariableTimeSetIds->InsertNextId(timeSet);
           this->VariableFileSetIds->InsertNextId(fileSet);
           this->AddVariableDescription(subLine);
-          sscanf(line, " %*s %*s %*s %*s %*d %*d %*s %s", subLine);
+          sscanf(line, " %*s %*s %*s %*s %*d %*d %*s %[^\t\n]", subLine);
         }
         else if (sscanf(line, " %*s %*s %*s %*s %d %s", &timeSet, subLine) == 2)
         {
           this->VariableTimeSetIds->InsertNextId(timeSet);
           this->AddVariableDescription(subLine);
-          sscanf(line, " %*s %*s %*s %*s %*d %*s %s", subLine);
+          sscanf(line, " %*s %*s %*s %*s %*d %*s %[^\t\n]", subLine);
         }
         else if (sscanf(line, " %*s %*s %*s %*s %s", subLine) == 1)
         {
           this->VariableTimeSetIds->InsertNextId(1);
           this->AddVariableDescription(subLine);
-          sscanf(line, " %*s %*s %*s %*s %*s %s", subLine);
+          sscanf(line, " %*s %*s %*s %*s %*s %[^\t\n]", subLine);
         }
         this->AddVariableType();
         if (asym)
@@ -786,19 +808,19 @@ int vtkEnSightReader::ReadCaseFileVariable(char* line)
           this->VariableTimeSetIds->InsertNextId(timeSet);
           this->VariableFileSetIds->InsertNextId(fileSet);
           this->AddVariableDescription(subLine);
-          sscanf(line, " %*s %*s %*s %*s %*d %*d %*s %s", subLine);
+          sscanf(line, " %*s %*s %*s %*s %*d %*d %*s %[^\t\n]", subLine);
         }
         else if (sscanf(line, " %*s %*s %*s %*s %d %s", &timeSet, subLine) == 2)
         {
           this->VariableTimeSetIds->InsertNextId(timeSet);
           this->AddVariableDescription(subLine);
-          sscanf(line, " %*s %*s %*s %*s %*d %*s %s", subLine);
+          sscanf(line, " %*s %*s %*s %*s %*d %*s %[^\t\n]", subLine);
         }
         else if (sscanf(line, " %*s %*s %*s %*s %s", subLine) == 1)
         {
           this->VariableTimeSetIds->InsertNextId(1);
           this->AddVariableDescription(subLine);
-          sscanf(line, " %*s %*s %*s %*s %*s %s", subLine);
+          sscanf(line, " %*s %*s %*s %*s %*s %[^\t\n]", subLine);
         }
         this->AddVariableType();
         if (asym)
@@ -1412,6 +1434,12 @@ int vtkEnSightReader::ReadCaseFile()
       // found FILE section
       vtkDebugMacro(<< "*** FILE section");
       ret = this->ReadCaseFileFile(line);
+    }
+    else if (strncmp(line, "SCRIPTS", 7) == 0)
+    {
+      // found SCRIPTS section
+      vtkDebugMacro(<< "*** SCRIPTS section");
+      ret = this->ReadCaseFileSripts(line);
     }
   }
 
@@ -2169,4 +2197,3 @@ void vtkEnSightReader::PrintSelf(ostream& os, vtkIndent indent)
   os << indent << "UseTimeSets: " << this->UseTimeSets << endl;
   os << indent << "UseFileSets: " << this->UseFileSets << endl;
 }
-VTK_ABI_NAMESPACE_END

--- a/IO/EnSight/vtkEnSightReader.h
+++ b/IO/EnSight/vtkEnSightReader.h
@@ -23,7 +23,6 @@
 #include "vtkGenericEnSightReader.h"
 #include "vtkIOEnSightModule.h" // For export macro
 
-VTK_ABI_NAMESPACE_BEGIN
 class vtkDataSet;
 class vtkDataSetCollection;
 class vtkEnSightReaderCellIdsType;
@@ -131,6 +130,8 @@ protected:
   int ReadCaseFileVariable(char* line);
   int ReadCaseFileTime(char* line);
   int ReadCaseFileFile(char* line);
+  int ReadCaseFileSripts(char* line);
+
   ///@}
 
   // set in UpdateInformation to value returned from ReadCaseFile
@@ -350,5 +351,4 @@ private:
   void operator=(const vtkEnSightReader&) = delete;
 };
 
-VTK_ABI_NAMESPACE_END
 #endif


### PR DESCRIPTION
This PR is to fix the following issue:

https://gitlab.kitware.com/paraview/paraview/-/issues/20819
https://discourse.paraview.org/t/fluent-2021-r1-ensight-case-gold-solution-files-to-paraview-5-9-0/7512/2

The Fluent export of EnSight files is now adding double quotes to the geo file and the to variable files. This is to allow paths with spaces or special characters. The VTK EnSight Reader creates the full path to the geo/var files adding to the path of the folder containing the case/encase file the string that is found using sscanf from the case file, but of course something like

C:\path\to\encas\/"my file.encas"

cannot be handled by Fopen. So the trick is to search for the double quotes, and if they are in the string they are being just removed. Of course I am supposing that the double quotes are just at the beginning and at the end of the string, since hopefully using double quotes in the name of the file should not be allowed.

So, VTK should now create the path like:

C:\path\to\encas\/my file.encas 
which can be handled by Fopen. The only additional change required was to fix the sscanf calls looking the the filename string, where the formatter %s is no more enough to find the filename since it can contain spaces, so the code is now looking for every character up until you get a newline or a tab. For simplicity I have not considered this eventuality for complex variables, since Fluent doesn't export files with complex variable. Also, I have changed the code only for the EnSight Gold Reader (binary and not) since Fluent only exports Gold Files.


Finally, in vtkEnSightReader I have also added functionality to check for the SCRIPTS variable of the encas file. This is a new optional variable which is used to give EnSight metadata stored in a xml file, where the metadata are units. So, I am finding this area of the encas file and skipping it, since not required for Paraview.


I have tested the changes locally on Windows, pointing to the files supplied in the above issue and a modified version where the geo file contained spaces, all of them loaded using pvpython.